### PR TITLE
Fix for musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ PROGNAME = tetris$(EXE)
 
 INSTALL = install
 
+CFLAGS += -lssp
+
 default: build
 	@echo Done.
 	@echo 'Now run ./$(PROGNAME) (or make install)'

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -122,5 +122,8 @@ int startgame()
 	}
 	if (!hiscores[0].score)
 		readhiscores(NULL);
-	return startgame_1p() && gameovermenu();
+	return startgame_1p() && gameovermenu(
+		(game->mode & MODE_BTYPE) && player1.lines == 0 ?
+		"SUCCESS!" : "GAME OVER"
+        );
 }

--- a/src/menu/gameover.c
+++ b/src/menu/gameover.c
@@ -229,13 +229,13 @@ entername:
 	}
 }
 
-int gameovermenu()
+int gameovermenu(const char *title)
 {
 	const char *menu[2] = {"Play again", "Exit"};
 	readhiscores(NULL);
 	if (ishiscore())
 		return hiscore_congrats(menu);
 	setwcurs(1, 2, 3);
-	drawbox(2, 3, 17, 5, "GAME OVER");
+	drawbox(2, 3, 17, 5, title);
 	return playagain_menu(menu, 4, 5);
 }

--- a/src/menu/menu.h
+++ b/src/menu/menu.h
@@ -82,6 +82,6 @@ int game_menu(int i, int x, int y);
 
 void show_hiscorelist(int x, int y);
 void show_hiscorelist5(int x, int y, int i);
-int gameovermenu();
+int gameovermenu(const char *title);
 
 #endif /* !menu_h */

--- a/src/menu/netplay.c
+++ b/src/menu/netplay.c
@@ -17,7 +17,7 @@ static char name_str[18];
 
 static int cursor = -1;
 
-static init_field(char *str, const char *val, int maxlen)
+static void init_field(char *str, const char *val, int maxlen)
 {
 	memset(str, ' ', maxlen+1);
 	if (val) {

--- a/src/netw/gameserver.c
+++ b/src/netw/gameserver.c
@@ -615,7 +615,7 @@ int main(int argc, char **argv)
 			write_logfile(argv[2]);
 		if (time(NULL)-t > 12*60*60) {
 			time(&t);
-			printf(ctime(&t));
+			printf("%s", ctime(&t));
 		}
 	}
 	return 0;

--- a/src/netw/tty_socket.c
+++ b/src/netw/tty_socket.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <sys/stat.h>

--- a/src/netw/tty_socket.c
+++ b/src/netw/tty_socket.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include "sock.h"
 #include "internal.h"
+#include <time.h>
 
 const struct invit *invit = NULL;
 char this_tty[8] = "";


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve functionality and fix issues. The most important changes include adding a new compiler flag, modifying the `gameovermenu` function to accept a title parameter, and fixing a missing return type in the `init_field` function.

### Build System Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10-R11): Added `-lssp` to `CFLAGS` to enhance security by enabling stack smashing protection.

### Game Logic Updates:
* [`src/game/game.c`](diffhunk://#diff-c7f48b03e0444d8996a2dc3b7d4c54a1827fd899427f5fc9aeb26377d01d654cL125-R128): Modified the `startgame` function to pass a custom title to `gameovermenu` based on the game mode and player lines.
* [`src/menu/gameover.c`](diffhunk://#diff-c00873b00fa6d3d7ce7c5dbd73a778871a18a65b296d3c68643e0ca94126eb54L232-R239): Updated the `gameovermenu` function to accept a `title` parameter and display it in the game over screen.
* [`src/menu/menu.h`](diffhunk://#diff-35e351e668f0123051bbf91d57e9554d73b31d953b4b829cc9450a04cd5407c4L85-R85): Updated the declaration of `gameovermenu` to include the `title` parameter.

### Codebase Fixes:
* [`src/menu/netplay.c`](diffhunk://#diff-66e680aec1a9c4d303f6637135c48d989a8aa19569be96f812ed4143dd5c0c55L20-R20): Fixed the `init_field` function by adding the missing `void` return type.
* [`src/netw/gameserver.c`](diffhunk://#diff-1d1afb228b3ecfa793f00197e89b038bab6bafb67f848e5e26a823727f614f74L618-R618): Corrected the `printf` call to properly format the output of `ctime`.

### Header Inclusions:
* [`src/netw/tty_socket.c`](diffhunk://#diff-d27348179b0f7f05ad0c0001646ba4c5f921834cf6b6d2751d7060e8b028a358R4): Added missing `#include <time.h>` to ensure time functions are available. [[1]](diffhunk://#diff-d27348179b0f7f05ad0c0001646ba4c5f921834cf6b6d2751d7060e8b028a358R4) [[2]](diffhunk://#diff-d27348179b0f7f05ad0c0001646ba4c5f921834cf6b6d2751d7060e8b028a358R17)